### PR TITLE
Features/RENW-600 - update breadcrumb UI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @vtex-apps/store-framework-devs
-docs/ @vtex-apps/technical-writers
+* @syatt-io/vtex

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,27 +1,5 @@
-#### What problem is this solving?
+## Description
 
-<!--- What is the motivation and context for this change? -->
+## Ticket
 
-#### How to test it?
-
-<!--- Don't forget to add a link to a Workspace where this branch is linked -->
-
-[Workspace](Link goes here!)
-
-#### Screenshots or example usage:
-
-<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->
-
-#### Describe alternatives you've considered, if any.
-
-<!--- Optional -->
-
-#### Related to / Depends on
-
-<!--- Optional -->
-
-#### How does this PR make you feel? [:link:](http://giphy.com/)
-
-<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->
-
-![](put .gif link here - can be found under "advanced" on giphy)
+## Preview

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,9 @@
 📢 Use this project, [contribute](https://github.com/vtex-apps/breadcrumb) to it or open issues to help evolve it using [Store Discussion](https://github.com/vtex-apps/store-discussion).
+
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-0-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 # Breadcrumb
@@ -15,7 +18,7 @@ The VTEX BreadCrumb is a navigation scheme that shows a user's browsing history 
 
 ```json
   dependencies: {
-    "vtex.breadcrumb": "1.x"
+    "renwil.breadcrumb": "1.x"
   }
 ```
 
@@ -29,11 +32,11 @@ The VTEX BreadCrumb is a navigation scheme that shows a user's browsing history 
   },
 ```
 
-| Prop name    | Type            | Description    | Default value                                                                                                                               |
-| ------------ | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | 
-| `showOnMobile`        | `Boolean`       | It determines whether Breadcrumb should also be displayed on mobile          | `false`              |
-| `homeIconSize`  | `Number`        | Controls the `size` property of [`IconHome`](https://github.com/vtex-apps/store-icons#icons)                                                                                                      | `26` |
-| `caretIconSize` | `Number`        | Controls the `size` property of [`IconCaret`](https://github.com/vtex-apps/store-icons#icons)                                                                                                     | `8` |
+| Prop name       | Type      | Description                                                                                   | Default value |
+| --------------- | --------- | --------------------------------------------------------------------------------------------- | ------------- |
+| `showOnMobile`  | `Boolean` | It determines whether Breadcrumb should also be displayed on mobile                           | `false`       |
+| `homeIconSize`  | `Number`  | Controls the `size` property of [`IconHome`](https://github.com/vtex-apps/store-icons#icons)  | `26`          |
+| `caretIconSize` | `Number`  | Controls the `size` property of [`IconCaret`](https://github.com/vtex-apps/store-icons#icons) | `8`           |
 
 :warning: The product's categories should appear as an array in one of this two formats:
 
@@ -55,25 +58,25 @@ categories = ['eletronics', 'eletronics-computers']
   },
 ```
 
-| Prop name    | Type            | Description    | Default value                                                                                                                               |
-| ------------ | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | 
-| `showOnMobile`        | `Boolean`       | It determines whether Breadcrumb should also be displayed on mobile          | `false`              |
-| `homeIconSize`  | `Number`        | Controls the `size` property of [`IconHome`](https://github.com/vtex-apps/store-icons#icons)                                                                                                      | `26` |
-| `caretIconSize` | `Number`        | Controls the `size` property of [`IconCaret`](https://github.com/vtex-apps/store-icons#icons)                                                                                                     | `8` |
-> ℹ️ *The `breadcrumb.search` block is specific for the Breadcrumb inside the search result page.* 
+| Prop name       | Type      | Description                                                                                   | Default value |
+| --------------- | --------- | --------------------------------------------------------------------------------------------- | ------------- |
+| `showOnMobile`  | `Boolean` | It determines whether Breadcrumb should also be displayed on mobile                           | `false`       |
+| `homeIconSize`  | `Number`  | Controls the `size` property of [`IconHome`](https://github.com/vtex-apps/store-icons#icons)  | `26`          |
+| `caretIconSize` | `Number`  | Controls the `size` property of [`IconCaret`](https://github.com/vtex-apps/store-icons#icons) | `8`           |
+
+> ℹ️ _The `breadcrumb.search` block is specific for the Breadcrumb inside the search result page._
 
 ## Customization
 
-In order to apply CSS customizations in this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization). 
+In order to apply CSS customizations in this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization).
 
 | CSS Handles |
-| ----------- | 
-| `container` | 
-| `link`      | 
-| `arrow`     | 
-| `homeLink`  | 
+| ----------- |
+| `container` |
+| `link`      |
+| `arrow`     |
+| `homeLink`  |
 | `termArrow` |
-
 
 ## Contributors ✨
 
@@ -84,6 +87,7 @@ Thanks goes to these wonderful people:
 <!-- markdownlint-disable -->
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/manifest.json
+++ b/manifest.json
@@ -1,20 +1,19 @@
 {
-  "vendor": "vtex",
+  "vendor": "renwil",
   "name": "breadcrumb",
-  "version": "1.9.4",
-  "title": "VTEX Breadcrumb",
+  "version": "0.0.1",
+  "title": "renwil Breadcrumb",
   "description": "Breadcrumb Component",
   "defaultLocale": "pt-BR",
   "builders": {
     "store": "0.x",
     "react": "3.x",
-    "docs": "0.x"
+    "docs": "0.x",
+    "messages": "1.x"
   },
   "mustUpdateAt": "2019-04-02",
   "categories": [],
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "scripts": {
     "postreleasy": "vtex publish --verbose"
   },

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,0 +1,3 @@
+{
+  "store/breadcrumbs.home": "Home"
+}

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1,0 +1,3 @@
+{
+  "store/breadcrumbs.home": "Accueil"
+}

--- a/react/components/BaseBreadcrumb.tsx
+++ b/react/components/BaseBreadcrumb.tsx
@@ -4,7 +4,7 @@ import { Link } from 'vtex.render-runtime'
 import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 import { IconCaret } from 'vtex.store-icons'
 import { useDevice } from 'vtex.device-detector'
-import { defineMessages } from 'react-intl'
+import { FormattedMessage } from 'react-intl'
 
 const CSS_HANDLES = [
   'container',
@@ -67,7 +67,6 @@ const Breadcrumb: React.FC<Props> = ({
   categoryTree,
   breadcrumb,
   showOnMobile = false,
-  // homeIconSize = 26,
   caretIconSize = 8,
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
@@ -76,13 +75,6 @@ const Breadcrumb: React.FC<Props> = ({
     () => breadcrumb ?? categoryTree ?? getCategoriesList(categories),
     [breadcrumb, categories, categoryTree]
   )
-
-  const messages = defineMessages({
-    home: { id: 'store/breadcrumbs.home' },
-  })
-
-  // eslint-disable-next-line no-console
-  console.log(navigationList, 'navigationList')
 
   const linkBaseClasses = 'dib pv1 link ph2 c-muted-2 hover-c-link'
   const shouldBeRendered = (showOnMobile && isMobile) || !isMobile
@@ -97,7 +89,7 @@ const Breadcrumb: React.FC<Props> = ({
         className={`${handles.link} ${handles.homeLink} ${linkBaseClasses} v-mid`}
         page="store.home"
       >
-        {messages.home.id}
+        <FormattedMessage id="store/breadcrumbs.home" />
       </Link>
       {navigationList.map(({ name, href }, i) => {
         let decodedName = ''

--- a/react/components/BaseBreadcrumb.tsx
+++ b/react/components/BaseBreadcrumb.tsx
@@ -2,8 +2,9 @@ import React, { Fragment, useMemo } from 'react'
 import unorm from 'unorm'
 import { Link } from 'vtex.render-runtime'
 import { useCssHandles, applyModifiers } from 'vtex.css-handles'
-import { IconCaret, IconHome } from 'vtex.store-icons'
+import { IconCaret } from 'vtex.store-icons'
 import { useDevice } from 'vtex.device-detector'
+import { defineMessages } from 'react-intl'
 
 const CSS_HANDLES = [
   'container',
@@ -66,7 +67,7 @@ const Breadcrumb: React.FC<Props> = ({
   categoryTree,
   breadcrumb,
   showOnMobile = false,
-  homeIconSize = 26,
+  // homeIconSize = 26,
   caretIconSize = 8,
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
@@ -75,6 +76,13 @@ const Breadcrumb: React.FC<Props> = ({
     () => breadcrumb ?? categoryTree ?? getCategoriesList(categories),
     [breadcrumb, categories, categoryTree]
   )
+
+  const messages = defineMessages({
+    home: { id: 'store/breadcrumbs.home' },
+  })
+
+  // eslint-disable-next-line no-console
+  console.log(navigationList, 'navigationList')
 
   const linkBaseClasses = 'dib pv1 link ph2 c-muted-2 hover-c-link'
   const shouldBeRendered = (showOnMobile && isMobile) || !isMobile
@@ -89,7 +97,7 @@ const Breadcrumb: React.FC<Props> = ({
         className={`${handles.link} ${handles.homeLink} ${linkBaseClasses} v-mid`}
         page="store.home"
       >
-        <IconHome size={homeIconSize} />
+        {messages.home.id}
       </Link>
       {navigationList.map(({ name, href }, i) => {
         let decodedName = ''

--- a/react/components/SearchBreadcrumb/index.tsx
+++ b/react/components/SearchBreadcrumb/index.tsx
@@ -21,9 +21,6 @@ const SearchBreadcrumb: FC<Props> = ({
     searchQuery?.data?.facets?.breadcrumb ??
     []
 
-  // eslint-disable-next-line no-console
-  console.log(breadcrumb, 'breadcrumbbreadcrumb')
-
   return (
     <>
       <SearchBreadcrumbStructuredData breadcrumb={breadcrumb} />

--- a/react/components/SearchBreadcrumb/index.tsx
+++ b/react/components/SearchBreadcrumb/index.tsx
@@ -21,6 +21,9 @@ const SearchBreadcrumb: FC<Props> = ({
     searchQuery?.data?.facets?.breadcrumb ??
     []
 
+  // eslint-disable-next-line no-console
+  console.log(breadcrumb, 'breadcrumbbreadcrumb')
+
   return (
     <>
       <SearchBreadcrumbStructuredData breadcrumb={breadcrumb} />

--- a/react/package.json
+++ b/react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vtex.breadcrumbs",
+  "name": "renwil.breadcrumbs",
   "description": "A Breadcrumb component.",
   "scripts": {
     "test": "vtex-test-tools test",


### PR DESCRIPTION
## Description
- Updated the app to use messages instead of an icon for home

## Ticket
RENW-600

## Preview
https://renw600--renwil.myvtex.com/accent-furniture?__bindingAddress=www.renwil.com/en&sc=2

![image](https://github.com/syatt-io/renwil-breadcrumb/assets/44775362/c55426b6-d3ab-4b88-a160-c2178b4538c7)
